### PR TITLE
Limit Sidekiq metrics to background namespace

### DIFF
--- a/dashboards/sidekiq/main.yml
+++ b/dashboards/sidekiq/main.yml
@@ -37,7 +37,7 @@ dashboard:
           fields:
             - COUNT
           tags:
-            namespace: '*'
+            namespace: 'background'
             action: '*'
     -
       title: 'Duration per job'
@@ -48,7 +48,7 @@ dashboard:
           fields:
             - MEAN
           tags:
-            namespace: '*'
+            namespace: 'background'
             action: '*'
     -
       title: 'Queue length'


### PR DESCRIPTION
If we use the wildcard to show duration metrics from all namespaces it contains
more than just Sidekiq worker metrics, but also controllers from the web
namespace for example. To remedy this, limit the namespace to the background
namespace.

This is only a problem if the user has overwritten the namespace in which case
they need to tweak this after the magic dashboard has been added.