### PR TITLE
Add descriptions for puma dashboard graphs

### DIFF
--- a/dashboards/puma/main.yml
+++ b/dashboards/puma/main.yml
@@ -17,6 +17,7 @@ dashboard:
             hostname: '*'
             type: "*"
     - title: Connection backlog
+      description: Number of established but unaccepted connections that are in the server backlog queue and still need to be processed.
       line_label: '%hostname%'
       metrics:
         - name: puma_connection_backlog
@@ -25,6 +26,7 @@ dashboard:
           tags:
             hostname: '*'
     - title: Pool capacity
+      description: Total thread pool capacity of the Puma server, including the number of threads that are waiting to be booted.
       line_label: '%hostname%'
       metrics:
         - name: puma_pool_capacity

--- a/dashboards/puma/main.yml
+++ b/dashboards/puma/main.yml
@@ -8,6 +8,7 @@ dashboard:
     and what the used/available concurrency is for those workers.
   graphs:
     - title: Threads running/max/idle
+      description: Counted over all workers, if running multiple processes.
       line_label: '%type% - %hostname%'
       metrics:
         - name: puma_threads
@@ -35,6 +36,7 @@ dashboard:
           tags:
             hostname: '*'
     - title: Puma worker info
+      description: Number of workers, old workers are still running old code after a deploy and should eventually be replaced with fresh workers running new code.
       line_label: '%type% - %hostname%'
       metrics:
         - name: puma_workers

--- a/dashboards/puma/main.yml
+++ b/dashboards/puma/main.yml
@@ -36,7 +36,7 @@ dashboard:
           tags:
             hostname: '*'
     - title: Puma worker info
-      description: Number of workers, old workers are still running old code after a deploy and should eventually be replaced with fresh workers running new code.
+      description: Number of workers per type. Old workers are still running old code after a deploy and should eventually be replaced with fresh workers running new code.
       line_label: '%type% - %hostname%'
       metrics:
         - name: puma_workers

--- a/dashboards/puma/main.yml
+++ b/dashboards/puma/main.yml
@@ -8,7 +8,7 @@ dashboard:
     and what the used/available concurrency is for those workers.
   graphs:
     - title: Threads running/max/idle
-      description: Counted over all workers, if running multiple processes.
+      description: Number of threads per type counted over all workers, if running multiple processes.
       line_label: '%type% - %hostname%'
       metrics:
         - name: puma_threads


### PR DESCRIPTION
Not sure if it's a good idea to add descriptions to all graphs, threads/workers seem self explanatory to me, but maybe I'm biased? 