### PR TITLE
Use Format: Size for erlang memory metric

### DIFF
--- a/dashboards/erlang/main.yml
+++ b/dashboards/erlang/main.yml
@@ -38,6 +38,7 @@ dashboard:
     -
       title: memory
       line_label: '%type% - %hostname%'
+      format: size
       metrics:
         - name: erlang_memory
           fields:


### PR DESCRIPTION
We currently don't set the proper formatting for this metric, by setting
the `format: size` we do.

Fixes: #14