### PR TITLE
Show memory in units that are collected in probe

### DIFF
--- a/dashboards/erlang/main.yml
+++ b/dashboards/erlang/main.yml
@@ -39,6 +39,7 @@ dashboard:
       title: memory
       line_label: '%type% - %hostname%'
       format: size
+      format_input: kilobyte
       metrics:
         - name: erlang_memory
           fields:


### PR DESCRIPTION
You can see how the metrics are collected here:

https://github.com/appsignal/appsignal-elixir/blob/350d8db1b3943456aa6f987afac8831cdad4f094/lib/appsignal/probes/erlang_probe.ex#L39