### PR TITLE
Add throughput and duration graphs to ActiveJob

### DIFF
--- a/dashboards/active_job/main.json
+++ b/dashboards/active_job/main.json
@@ -37,7 +37,7 @@
       },
       {
         "title": "Job status per queue with priority",
-        "description": "Processed and failed jobs per queue with priority.",
+        "description": "Processed and failed jobs per queue with priority. This graph may be empty if the configured adapter does not support a priority system.",
         "line_label": "%queue% queue - priority %priority% - %status%",
         "display": "LINE",
         "format": "number",
@@ -67,6 +67,60 @@
           }
         ],
         "type": "timeseries"
+      },
+      {
+        "type": "timeseries",
+        "display": "line",
+        "title": "Throughput per job class",
+        "line_label": "%namespace% - %action%",
+        "format": "number",
+        "metrics": [
+          {
+            "name": "transaction_duration",
+            "fields": [
+              {
+                "field": "count"
+              }
+            ],
+            "tags": [
+              {
+                "key": "namespace",
+                "value": "background"
+              },
+              {
+                "key": "action",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "line",
+        "title": "Duration per job class",
+        "line_label": "%namespace% - %action%",
+        "format": "duration",
+        "metrics": [
+          {
+            "name": "transaction_duration",
+            "fields": [
+              {
+                "field": "mean"
+              }
+            ],
+            "tags": [
+              {
+                "key": "namespace",
+                "value": "background"
+              },
+              {
+                "key": "action",
+                "value": "*"
+              }
+            ]
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
The Sidekiq dashboard also has these graphs, I copied them from there.
It shows the throughput for all actions in the "background" namespace
and the duration for those actions in the "background" namespace.

These two graphs make the dashboard more complete and provides more
information based on the `transaction_duration` metric.

Also be more clear that the priority graph can be empty if the adapter
doesn't support it.

## Screenshots

![image](https://user-images.githubusercontent.com/282402/87532484-86116300-c693-11ea-890d-930cb3d34665.png)
