### PR TITLE
Add ActionMailer dashboard

### DIFF
--- a/dashboards/action_mailer/main.json
+++ b/dashboards/action_mailer/main.json
@@ -11,7 +11,7 @@
         "description": "Deliveries per mailer/action",
         "line_label": "%mailer%#%action%",
         "display": "LINE",
-        "format": "number",
+        "format": "throughput",
         "draw_null_as_zero": true,
         "metrics": [
           {

--- a/dashboards/action_mailer/main.json
+++ b/dashboards/action_mailer/main.json
@@ -1,0 +1,69 @@
+{
+  "metric_keys": [
+    "action_mailer_process"
+  ],
+  "dashboard": {
+    "title": "ActionMailer metrics",
+    "description": "This dashboard shows ActionMailer metrics for all your mailers.",
+    "visuals": [
+      {
+        "title": "ActionMailer Deliveries",
+        "description": "Deliveries per mailer/action",
+        "line_label": "%mailer%#%action%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "action_mailer_process",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "action",
+                "value": "*"
+              },
+              {
+                "key": "mailer",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "ActionMailer deliveries",
+        "description": "Deliveries per mailer/action, shown in percentage per minute.",
+        "line_label": "%mailer%#%action%",
+        "display": "AREA_RELATIVE",
+        "format": "percent",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "action_mailer_process",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "action",
+                "value": "*"
+              },
+              {
+                "key": "mailer",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add ActionMailer dashboard with two graphs:

* One for throughput per mailer/method combination
* One that shows a relative percentage graph (e.g. "stacked graph") to quickly identify what mailer took up most resources.

Related: https://github.com/appsignal/appsignal-ruby/pull/669

![Screenshot 2020-11-30 at 14 03 31](https://user-images.githubusercontent.com/28408/100613659-30251b00-3315-11eb-8e75-ac619690a211.png)
