### PR TITLE
Clarify Redis memory usage label

### DIFF
--- a/dashboards/sidekiq/main.json
+++ b/dashboards/sidekiq/main.json
@@ -230,7 +230,7 @@
       {
         "type": "timeseries",
         "display": "line",
-        "title": "Memory usage",
+        "title": "Redis memory usage",
         "line_label": "%name% - %hostname%",
         "format": "size",
         "format_input": "byte",


### PR DESCRIPTION
On the Sidekiq magic dashboard, clarify memory usage with "Redis memory
usage", so people don't confuse it with the Sidekiq process memory
usage.

The data is fetched from `Sidekiq.redis_info` which does the same as
`redis-cli info` which is all about Redis data and metrics.

https://github.com/mperham/sidekiq/blob/ed8483784348976edc3943ec235bde14e4626210/lib/sidekiq.rb#L113-L121