### PR TITLE
Update Puma pool capacity description

### DIFF
--- a/dashboards/puma/main.json
+++ b/dashboards/puma/main.json
@@ -60,7 +60,7 @@
         "type": "timeseries",
         "display": "line",
         "title": "Pool capacity",
-        "description": "Total thread pool capacity of the Puma server, including the number of threads that are waiting to be booted.",
+        "description": "Total thread pool availablity of the Puma server. How many idle threads are ready to receive requests.",
         "line_label": "%hostname%",
         "metrics": [
           {


### PR DESCRIPTION
Update the description of the `puma_pool_capacity` metric, which is the
`pool_capacity` in Puma. I've updated it to match the Puma docs more
closely:

> pool_capacity: the number of requests that the server is capable of
> taking right now. For example if the number is 5 then it means there
> are 5 threads sitting idle ready to take a request. If one request
> comes in, then the value would be 4 until it finishes processing. If
> the minimum threads allowed is zero, this number will still have a
> maximum value of the maximum threads allowed.

https://github.com/puma/puma/blob/0256d71e607eb8b5fb39e77541dc3ca4db136e86/docs/stats.md