### PR TITLE
Add graph for Erlang atom usage

### DIFF
--- a/dashboards/erlang/main.json
+++ b/dashboards/erlang/main.json
@@ -111,6 +111,35 @@
             ]
           }
         ]
+      },
+      {
+        "type": "timeseries",
+        "display": "line",
+        "title": "Atom usage",
+        "description": "Usage of atoms in Erlang and the configured limit.",
+        "line_label": "%type% - %hostname%",
+        "format": "size",
+        "format_input": "kilobyte",
+        "metrics": [
+          {
+            "name": "erlang_atoms",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "type",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
This PR depends on
https://github.com/appsignal/appsignal-elixir/pull/651 which tracks
metrics for the Erlang atom usage.