### PR TITLE
Add scheduler utilization to Erlang magic dashboard

### DIFF
--- a/dashboards/erlang/main.json
+++ b/dashboards/erlang/main.json
@@ -140,6 +140,38 @@
             ]
           }
         ]
+      },
+      {
+        "type": "timeseries",
+        "display": "line",
+        "title": "Scheduler utilization",
+        "description": "Load distribution for Erlang schedulers.",
+        "line_label": "%type% #%id% - %hostname%",
+        "format": "percent",
+        "metrics": [
+          {
+            "name": "erlang_scheduler_utilization",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              },
+              {
+                "key": "id",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "scheduler"
+              }
+            ]
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
This commit adds a graph displaying the scheduler utilization metric. It shows a line for each of the schedulers in the Erlang node that is being monitored, mimicking the UI of the Erlang observer.