### PR TITLE
Add run queue length to Erlang magic dashboard

### DIFF
--- a/dashboards/erlang/main.json
+++ b/dashboards/erlang/main.json
@@ -172,6 +172,33 @@
             ]
           }
         ]
+      },
+      {
+        "type": "timeseries",
+        "display": "line",
+        "title": "Run queue length",
+        "description": "Total for all schedulers, by type.",
+        "line_label": "%type% - %hostname%",
+        "metrics": [
+          {
+            "name": "total_run_queue_lengths",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "type",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
The run queue length for a given scheduler is an interesting metric to be able to observe, especially alongside the scheduler utilization metric. The metric is already being reported by the Erlang probe in the Elixir integration, but it is not displayed in the magic dashboard. This commit adds a graph of run queue lengths to the magic dashboard.