### PR TITLE
Display Ruby VM probe metrics as gauges with a hostname tag

### DIFF
--- a/dashboards/ruby_vm/main.json
+++ b/dashboards/ruby_vm/main.json
@@ -38,13 +38,7 @@
             "name": "gc_count",
             "fields": [
               {
-                "field": "MEAN"
-              },
-              {
-                "field": "P90"
-              },
-              {
-                "field": "P95"
+                "field": "GAUGE"
               }
             ],
             "tags": [
@@ -69,13 +63,7 @@
             "name": "heap_slots",
             "fields": [
               {
-                "field": "MEAN"
-              },
-              {
-                "field": "P90"
-              },
-              {
-                "field": "P95"
+                "field": "GAUGE"
               }
             ],
             "tags": [
@@ -100,13 +88,7 @@
             "name": "ruby_vm",
             "fields": [
               {
-                "field": "MEAN"
-              },
-              {
-                "field": "P90"
-              },
-              {
-                "field": "P95"
+                "field": "GAUGE"
               }
             ],
             "tags": [

--- a/dashboards/ruby_vm/main.json
+++ b/dashboards/ruby_vm/main.json
@@ -142,31 +142,6 @@
           }
         ],
         "type": "timeseries"
-      },
-      {
-        "title": "GC total time",
-        "description": "The total garbage collection time, in milliseconds",
-        "line_label": "%name%",
-        "display": "LINE",
-        "format": "duration",
-        "draw_null_as_zero": true,
-        "metrics": [
-          {
-            "name": "gc_total_time",
-            "fields": [
-              {
-                "field": "GAUGE"
-              }
-            ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
-          }
-        ],
-        "type": "timeseries"
       }
     ]
   }

--- a/dashboards/ruby_vm/main.json
+++ b/dashboards/ruby_vm/main.json
@@ -148,7 +148,7 @@
         "description": "The total garbage collection time, in milliseconds",
         "line_label": "%name%",
         "display": "LINE",
-        "format": "number",
+        "format": "duration",
         "draw_null_as_zero": true,
         "metrics": [
           {

--- a/dashboards/ruby_vm/main.json
+++ b/dashboards/ruby_vm/main.json
@@ -21,7 +21,12 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": []
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
           }
         ],
         "type": "timeseries"
@@ -44,6 +49,10 @@
             "tags": [
               {
                 "key": "metric",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
                 "value": "*"
               }
             ]
@@ -70,6 +79,10 @@
               {
                 "key": "metric",
                 "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
               }
             ]
           }
@@ -95,6 +108,10 @@
               {
                 "key": "metric",
                 "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
               }
             ]
           }
@@ -116,7 +133,12 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": []
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
           }
         ],
         "type": "timeseries"
@@ -136,7 +158,12 @@
                 "field": "GAUGE"
               }
             ],
-            "tags": []
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
           }
         ],
         "type": "timeseries"


### PR DESCRIPTION
## Change all Ruby VM dashboard metrics to gauges

We've noticed that distributions are not a good fit for this. For more
PR https://github.com/appsignal/appsignal-ruby/pull/866 on the Ruby gem.

## Add hostname to Ruby VM dashboard metrics

The added hostname tag allows us to tell multiple hosts from each other
and graph them separately. If we do not, an app with multiple hosts
would have hosts overwrite one another's metrics. Only the last reported
value would be stored and shown.

## Change GC time to duration

I think we're recording time here, so let's display it as time too.

## Remove GC time graph for now

It's not reporting any values unless the GC profiler is enabled, which
it isn't by default. I want to avoid confusion by shipping an always
empty graph by default so I'm removing it now.
We can always add it back later.
