### PR TITLE
Add Garbage Collection time graph to Ruby VM

### DIFF
--- a/dashboards/ruby_vm/main.json
+++ b/dashboards/ruby_vm/main.json
@@ -142,6 +142,31 @@
           }
         ],
         "type": "timeseries"
+      },
+      {
+        "title": "GC time",
+        "description": "The Garbage Collection time measured. (Not enabled by default.)",
+        "line_label": "%name%",
+        "display": "LINE",
+        "format": "duration",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "gc_time",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
       }
     ]
   }

--- a/dashboards/ruby_vm/main.json
+++ b/dashboards/ruby_vm/main.json
@@ -145,7 +145,7 @@
       },
       {
         "title": "GC time",
-        "description": "The Garbage Collection time measured. (Not enabled by default.)",
+        "description": "The Garbage Collection time measured, if Ruby GC profiling is enabled",
         "line_label": "%name%",
         "display": "LINE",
         "format": "duration",


### PR DESCRIPTION
Add the Garbage Collection time graph back to the Ruby VM dashboard
after it was added and removed in PR
https://github.com/appsignal/public_config/pull/38.

I've updated the metric name to `gc_time` in Ruby gem PR because it
doesn't report the total time anymore:
https://github.com/appsignal/appsignal-ruby/pull/874
https://github.com/appsignal/appsignal-ruby/pull/867

This graph will not have any data by default. We need a way to direct
users to our docs on how to enable this. We cannot link to this from the
graph description that I could tell, the graph description does not
support any link format.

We need to write some docs for this, basically saying: Add
`GC::Profiler.enable` to your app, but not in production or not for long
in production because it may negatively impact the performance of your
app.

Also, to update existing dashboards, I refer to the dashboard update
issue we should pick up:
https://github.com/appsignal/appsignal-server/issues/4770

Part of https://github.com/appsignal/appsignal-ruby/issues/868
