### PR TITLE
Add validation to CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,22 @@
+version: v1.0
+name: Public config validation
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+# Cancel all running and queued workflows before this one
+auto_cancel:
+  running:
+    # Ignore main AND develop branch as we want it to build all workflows
+    when: "branch != 'main' AND branch != 'develop'"
+
+blocks:
+  - name: Validate
+    task:
+      jobs:
+      - name: Validate
+        commands:
+          - checkout
+          - rake validate

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ The `public_config` repository is a place for AppSignal's public configuration. 
 ## Magic Dashboards
 
 Magic Dashboards can be found in the `dashboards/` sub directory. Each directory is a different integration, like a language or package. Each dashboard is its own file in these sub-directories in the JSON format.
+
+### Validation
+
+To validate all dashboards in this repository, run the following command. To pass the validation, fix any issues that are printed.
+
+```
+rake validate
+```

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ class Dashboard
     return unless definition
 
     required_field "metric_keys"
+    required_field "dashboard"
     required_field "dashboard", "title"
     required_field "dashboard", "description"
     required_field "dashboard", "visuals"
@@ -40,7 +41,7 @@ class Dashboard
             end
           end
 
-          # Validate metrictags
+          # Validate metric tags
           metric.fetch("tags", []).each_with_index do |_tag, tag_index|
             REQUIRED_VISUAL_METRIC_TAG_FIELDS.each do |tag_field|
               required_field(*metric_base, "tags", tag_index, tag_field)

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,8 @@ class Dashboard
   end
 
   def validate
+    return unless definition
+
     required_field "metric_keys"
     required_field "dashboard", "title"
     required_field "dashboard", "description"
@@ -102,7 +104,6 @@ task :validate do
       dashboard.definition = JSON.parse(file_contents)
     rescue StandardError
       dashboard.issues << "Unable to parse the Dashboard JSON for '#{file_path}'"
-      next
     end
 
     dashboard.validate

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,126 @@
+require "json"
+
+class Dashboard
+  attr_reader :path
+  attr_accessor :definition
+
+  def initialize(path)
+    @path = path
+  end
+
+  def issues
+    @issues ||= []
+  end
+
+  def validate
+    required_field "metric_keys"
+    required_field "dashboard", "title"
+    required_field "dashboard", "description"
+    required_field "dashboard", "visuals"
+
+    dashboard.fetch("visuals", []).each_with_index do |visual, visual_index|
+      visual_base = ["dashboard", "visuals", visual_index]
+      # Validate base visual fields
+      REQUIRED_VISUAL_FIELDS.each do |field|
+        required_field(*visual_base, field)
+      end
+
+      visual.fetch("metrics", []).each_with_index do |metric, metric_index|
+        # Validate base metric fields
+        REQUIRED_VISUAL_METRIC_FIELDS.each do |metric_field|
+          metric_base = [*visual_base, "metrics", metric_index]
+          required_field(*metric_base, metric_field)
+
+          # Validate metric fields
+          metric.fetch("fields", []).each_with_index do |_field, field_index|
+            REQUIRED_VISUAL_METRIC_FIELD_FIELDS.each do |field_field|
+              required_field(*metric_base, "fields", field_index, field_field)
+            end
+          end
+
+          # Validate metrictags
+          metric.fetch("tags", []).each_with_index do |_tag, tag_index|
+            REQUIRED_VISUAL_METRIC_TAG_FIELDS.each do |tag_field|
+              required_field(*metric_base, "tags", tag_index, tag_field)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  REQUIRED_VISUAL_FIELDS = [
+    "type",
+    "title",
+    "line_label",
+    "display",
+    "format",
+    "draw_null_as_zero",
+    "metrics"
+  ].freeze
+  REQUIRED_VISUAL_METRIC_FIELDS = [
+    "name",
+    "fields"
+  ].freeze
+  REQUIRED_VISUAL_METRIC_FIELD_FIELDS = [
+    "field"
+  ].freeze
+  REQUIRED_VISUAL_METRIC_TAG_FIELDS = [
+    "key",
+    "value"
+  ].freeze
+
+  def field_present?(*field)
+    !definition.dig(*field).nil?
+  end
+
+  def dashboard_field_present?(field)
+    field_present?("dashboard", *field)
+  end
+
+  def required_field(*field)
+    return if field_present?(*field)
+
+    issues << "No '#{Array(field).join(".")}' field present"
+  end
+
+  def dashboard
+    definition["dashboard"]
+  end
+end
+
+task :validate do
+  issue_count = 0
+  base_path = "dashboards"
+  Dir.glob("**/*.json", :base => base_path).sort.each do |file_path|
+    dashboard = Dashboard.new(file_path)
+
+    file_contents = File.read(File.join(base_path, file_path))
+    begin
+      dashboard.definition = JSON.parse(file_contents)
+    rescue StandardError
+      dashboard.issues << "Unable to parse the Dashboard JSON for '#{file_path}'"
+      next
+    end
+
+    dashboard.validate
+    next if dashboard.issues.empty?
+
+    issue_count += dashboard.issues.count
+    puts "Dashboard: #{dashboard.path}"
+    puts "Issues:"
+    dashboard.issues.each do |issue|
+      puts "- #{issue}"
+    end
+    puts
+  end
+
+  if issue_count.positive?
+    puts "#{issue_count} issues found"
+    exit 1
+  else
+    puts "No issues found"
+  end
+end

--- a/dashboards/active_job/main.json
+++ b/dashboards/active_job/main.json
@@ -74,6 +74,7 @@
         "title": "Throughput per job class",
         "line_label": "%namespace% - %action%",
         "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "transaction_duration",
@@ -101,6 +102,7 @@
         "title": "Duration per job class",
         "line_label": "%namespace% - %action%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "transaction_duration",

--- a/dashboards/erlang/main.json
+++ b/dashboards/erlang/main.json
@@ -12,7 +12,7 @@
         "title": "IO",
         "line_label": "%type% - %hostname%",
         "format": "number",
-        "draw_null_as_zero": false,
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "erlang_io",
@@ -40,7 +40,7 @@
         "title": "Schedulers",
         "line_label": "%type% - %hostname%",
         "format": "number",
-        "draw_null_as_zero": false,
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "erlang_schedulers",
@@ -68,7 +68,7 @@
         "title": "Processes",
         "line_label": "%type% - %hostname%",
         "format": "number",
-        "draw_null_as_zero": false,
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "erlang_processes",
@@ -97,7 +97,7 @@
         "line_label": "%type% - %hostname%",
         "format": "size",
         "format_input": "kilobyte",
-        "draw_null_as_zero": false,
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "erlang_memory",
@@ -127,7 +127,7 @@
         "line_label": "%type% - %hostname%",
         "format": "size",
         "format_input": "kilobyte",
-        "draw_null_as_zero": false,
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "erlang_atoms",
@@ -156,7 +156,7 @@
         "description": "Load distribution for Erlang schedulers.",
         "line_label": "%type% #%id% - %hostname%",
         "format": "percent",
-        "draw_null_as_zero": false,
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "erlang_scheduler_utilization",
@@ -189,7 +189,7 @@
         "description": "Total for all schedulers, by type.",
         "line_label": "%type% - %hostname%",
         "format": "number",
-        "draw_null_as_zero": false,
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "total_run_queue_lengths",

--- a/dashboards/erlang/main.json
+++ b/dashboards/erlang/main.json
@@ -11,6 +11,8 @@
         "display": "line",
         "title": "IO",
         "line_label": "%type% - %hostname%",
+        "format": "number",
+        "draw_null_as_zero": false,
         "metrics": [
           {
             "name": "erlang_io",
@@ -37,6 +39,8 @@
         "display": "line",
         "title": "Schedulers",
         "line_label": "%type% - %hostname%",
+        "format": "number",
+        "draw_null_as_zero": false,
         "metrics": [
           {
             "name": "erlang_schedulers",
@@ -63,6 +67,8 @@
         "display": "line",
         "title": "Processes",
         "line_label": "%type% - %hostname%",
+        "format": "number",
+        "draw_null_as_zero": false,
         "metrics": [
           {
             "name": "erlang_processes",
@@ -91,6 +97,7 @@
         "line_label": "%type% - %hostname%",
         "format": "size",
         "format_input": "kilobyte",
+        "draw_null_as_zero": false,
         "metrics": [
           {
             "name": "erlang_memory",
@@ -120,6 +127,7 @@
         "line_label": "%type% - %hostname%",
         "format": "size",
         "format_input": "kilobyte",
+        "draw_null_as_zero": false,
         "metrics": [
           {
             "name": "erlang_atoms",
@@ -148,6 +156,7 @@
         "description": "Load distribution for Erlang schedulers.",
         "line_label": "%type% #%id% - %hostname%",
         "format": "percent",
+        "draw_null_as_zero": false,
         "metrics": [
           {
             "name": "erlang_scheduler_utilization",
@@ -179,6 +188,8 @@
         "title": "Run queue length",
         "description": "Total for all schedulers, by type.",
         "line_label": "%type% - %hostname%",
+        "format": "number",
+        "draw_null_as_zero": false,
         "metrics": [
           {
             "name": "total_run_queue_lengths",

--- a/dashboards/heroku/status.json
+++ b/dashboards/heroku/status.json
@@ -11,6 +11,7 @@
         "line_label": "%name% %code%",
         "display": "LINE",
         "draw_null_as_zero": false,
+        "format": "number",
         "metrics": [
           {
             "name": "heroku_status",

--- a/dashboards/mongodb/main.json
+++ b/dashboards/mongodb/main.json
@@ -12,6 +12,7 @@
         "title": "MongoDB Database Throughput",
         "line_label": "%database%",
         "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "mongodb_query_duration",
@@ -35,6 +36,7 @@
         "title": "MongoDB Database Query Duration Mean",
         "line_label": "%database%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "mongodb_query_duration",
@@ -58,6 +60,7 @@
         "title": "MongoDB Database Query Duration 95th Percentile",
         "line_label": "%database%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "mongodb_query_duration",

--- a/dashboards/nextjs/main.json
+++ b/dashboards/nextjs/main.json
@@ -13,6 +13,7 @@
         "description": "Length of time it takes for the page to start and finish hydrating",
         "line_label": "%name% %field%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "nextjs_hydration_time",
@@ -37,6 +38,7 @@
         "description": "Length of time it takes for a page to start rendering after a route change",
         "line_label": "%name% %field%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "nextjs_route_change_to_render_time",
@@ -61,6 +63,7 @@
         "description": "Length of time it takes for a page to finish render after a route change",
         "line_label": "%name% %field%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "nextjs_render_time",

--- a/dashboards/process_memory/main.json
+++ b/dashboards/process_memory/main.json
@@ -14,6 +14,7 @@
         "line_label": "%process_name% - %hostname%",
         "format": "size",
         "format_input": "kilobyte",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "process_rss",
@@ -43,6 +44,7 @@
         "line_label": "%process_name% - %hostname%",
         "format": "size",
         "format_input": "kilobyte",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "process_rss",

--- a/dashboards/puma/main.json
+++ b/dashboards/puma/main.json
@@ -9,6 +9,8 @@
       {
         "type": "timeseries",
         "display": "line",
+        "format": "number",
+        "draw_null_as_zero": true,
         "title": "Threads running/max/idle",
         "description": "Number of threads per type counted over all workers, if running multiple processes.",
         "line_label": "%type% - %hostname%",
@@ -36,6 +38,8 @@
       {
         "type": "timeseries",
         "display": "line",
+        "format": "number",
+        "draw_null_as_zero": true,
         "title": "Connection backlog",
         "description": "Number of established but unaccepted connections that are in the server backlog queue and still need to be processed.",
         "line_label": "%hostname%",
@@ -59,6 +63,8 @@
       {
         "type": "timeseries",
         "display": "line",
+        "format": "number",
+        "draw_null_as_zero": true,
         "title": "Pool capacity",
         "description": "Total thread pool availablity of the Puma server. How many idle threads are ready to receive requests.",
         "line_label": "%hostname%",
@@ -82,6 +88,8 @@
       {
         "type": "timeseries",
         "display": "line",
+        "format": "number",
+        "draw_null_as_zero": true,
         "title": "Puma worker info",
         "description": "Number of workers per type. Old workers are still running old code after a deploy and should eventually be replaced with fresh workers running new code.",
         "line_label": "%type% - %hostname%",

--- a/dashboards/sidekiq/main.json
+++ b/dashboards/sidekiq/main.json
@@ -11,6 +11,8 @@
         "display": "line",
         "title": "Overall job status",
         "line_label": "%name% - %hostname% - %status%",
+        "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "sidekiq_job_count",
@@ -38,6 +40,7 @@
         "title": "Job status per queue",
         "line_label": "%name% - %queue% - %status%",
         "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "sidekiq_queue_job_count",
@@ -65,6 +68,7 @@
         "title": "Throughput per worker",
         "line_label": "%name% - %namespace% - %action%",
         "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "transaction_duration",
@@ -92,6 +96,7 @@
         "title": "Duration per worker",
         "line_label": "%name% - %namespace% - %action%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "transaction_duration",
@@ -119,6 +124,7 @@
         "title": "Queue length",
         "line_label": "%name% - %hostname% - %queue%",
         "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "sidekiq_queue_length",
@@ -146,6 +152,7 @@
         "title": "Queue latency",
         "line_label": "%name% - %hostname% - %queue%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "sidekiq_queue_latency",
@@ -173,6 +180,7 @@
         "title": "Worker / Processes count",
         "line_label": "%name% - %hostname%",
         "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "sidekiq_worker_count",
@@ -210,6 +218,7 @@
         "title": "Connection count",
         "line_label": "%name% - %hostname%",
         "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "sidekiq_connection_count",
@@ -234,6 +243,7 @@
         "line_label": "%name% - %hostname%",
         "format": "size",
         "format_input": "byte",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "sidekiq_memory_usage",

--- a/dashboards/web-vitals/main.json
+++ b/dashboards/web-vitals/main.json
@@ -13,6 +13,7 @@
         "description": "Time between the browser requesting a page and when it receives the first byte of information from the server.",
         "line_label": "%name% %field%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "webvital_ttfb",
@@ -37,6 +38,7 @@
         "description": "Duration before the browser renders the first bit of content from the DOM.",
         "line_label": "%name% %field%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "webvital_fcp",
@@ -61,6 +63,7 @@
         "description": "The point in time in the page load timeline when the page's main content has likely loaded.",
         "line_label": "%name% %field%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "webvital_lcp",
@@ -85,6 +88,7 @@
         "description": "Time from when a user first interacts with a page to the time when the browser is actually able to respond to that interaction.",
         "line_label": "%name% %field%",
         "format": "duration",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "webvital_fid",
@@ -109,6 +113,7 @@
         "description": "Quantifies how often users experience unexpected layout shifts",
         "line_label": "%name% %field%",
         "format": "number",
+        "draw_null_as_zero": true,
         "metrics": [
           {
             "name": "webvital_cls",


### PR DESCRIPTION
## Add validation to CI

Check if required fields are present. Check this on the dashboard,
visual, metric, metric fields and metric tags levels.

I tried to keep these validations very basic. I don't want over engineer
this for this first version. We can always expand it later.

Things to add, if we want:

- Basic type checking
- Enum value checking (display, format and format_input fields)
- Invalid fields: is a field specified that does nothing
- etc.

### Default fields

Fields with default values that are currently not present in all
dashboards, are now required. I'll fix any validation issues in the next
commit.

These fields are `draw_null_as_zero` and `format`. The
`draw_null_as_zero` field has `true` as default value in the database
and the `format` field is always set by the creation code.

These fields are always set upon creation. Let's make sure that we
define them here explicitly too. This makes the updater process easier
by comparing the full definitions in JSON.

Otherwise, if a default would ever change, it would invalidate all the
magic dashboard version comparisons.

Part of https://github.com/appsignal/appsignal-server/issues/4770

## Add missing default fields

These fields are set upon creation the database, or have fallback for
them in the front-end code. Let's be explicit what we want these fields
to be. See previous commit for more context.
