### PR TITLE
Add READMEs for deprecated dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Magic Dashboards can be found in the `dashboards/` sub directory. Each directory
 - [Erlang](/dashboards/erlang/)
 - [Heroku](/dashboards/heroku/)
 - [MongoDB](/dashboards/mongodb/)
-- [Next.js](/dashboards/nextjs/)
+- [Next.js](/dashboards/nextjs/) (deprecated)
 - [NGINX](/dashboards/nginx/)
 - [Node.js](/dashboards/nodejs/)
 - [Oban](/dashboards/oban/)
 - [Puma](/dashboards/puma/)
 - [Ruby VM](/dashboards/ruby_vm/)
 - [Sidekiq](/dashboards/sidekiq/)
-- [Web Vitals](/dashboard/web-vitals/)
+- [Web Vitals](/dashboard/web-vitals/) (deprecated)
 
 ### Validation
 

--- a/dashboards/nextjs/README.md
+++ b/dashboards/nextjs/README.md
@@ -1,0 +1,3 @@
+# Next.js Web Vitals magic dashboard (deprecated)
+
+As of version 3.x of the AppSignal for Node.js integration, the metrics used on the Next.js Web Vitals magic dashboard are no longer emitted, and therefore this magic dashboard is no longer created.

--- a/dashboards/nodejs/README.md
+++ b/dashboards/nodejs/README.md
@@ -1,0 +1,14 @@
+# Node.js magic dashboards
+
+There are two magic dashboards for the Node.js programming language:
+
+- [Heap Statistics](#heap-statistics-magic-dashboard)
+- [Postgres](#postgres-magic-dashboard-deprecated) (deprecated)
+
+## Heap statistics magic dashboard
+
+TO-DO: write this
+
+## Postgres magic dashboard (deprecated)
+
+As of version 3.x of the AppSignal for Node.js integration, the metrics used on the Postgres magic dashboard are no longer emitted, and therefore this magic dashboard is no longer created.

--- a/dashboards/web-vitals/README.md
+++ b/dashboards/web-vitals/README.md
@@ -1,0 +1,3 @@
+# Next.js Web Vitals magic dashboard (deprecated)
+
+As of version 3.x of the AppSignal for Node.js integration, the metrics used on the Next.js Web Vitals magic dashboard are no longer emitted, and therefore this magic dashboard is no longer created.


### PR DESCRIPTION
Adds a README for each deprecated dashboard (Node.js Postgres, Next.js and Web Vitals) explaining that the dashboard is deprecated (and not explaining the actual dashboard)

A re-do of #49. Part of #46.