### PR TITLE
Add Vector/PostgresQL Magic Dashboard

### DIFF
--- a/dashboards/postgres/README.md
+++ b/dashboards/postgres/README.md
@@ -1,0 +1,17 @@
+# PostgresQL Dashboard
+
+AppSignal tracks PostgresQL metrics through its [Vector sink](https://docs.appsignal.com/vector.html).
+When enabled, it shows a subset of the [metrics listed in Vector's documentation](https://vector.dev/docs/reference/configuration/sources/postgresql_metrics/):
+
+- pg_stat_database_deadlocks_total
+- pg_stat_database_numbackends
+- pg_stat_database_temp_bytes_total
+- pg_stat_database_temp_files_total
+- pg_stat_database_tup_deleted_total
+- pg_stat_database_tup_fetched_total
+- pg_stat_database_tup_inserted_total
+- pg_stat_database_tup_returned_total
+- pg_stat_database_tup_updated_total
+- pg_stat_database_xact_commit_total
+- pg_stat_database_xact_rollback_total
+- up

--- a/dashboards/postgres/main.json
+++ b/dashboards/postgres/main.json
@@ -1,0 +1,400 @@
+{
+  "metric_keys": [
+    "vector_pg_up"
+  ],
+  "dashboard": {
+    "title": "PostgreSQL",
+    "description": "",
+    "visuals": [
+      {
+        "title": "pg_stat_database_deadlocks_total",
+        "description": "Number of deadlocks detected in this database.",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_deadlocks_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_numbackends",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_numbackends",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_temp_bytes_total",
+        "description": "Total amount of data written to temporary files by queries in this database. ",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_temp_bytes_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_temp_files_total",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_temp_files_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_tup_deleted_total",
+        "description": "Number of rows deleted by queries in this database.",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_tup_deleted_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_tup_fetched_total",
+        "description": "Number of rows fetched by queries in this database.",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_tup_fetched_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_tup_inserted_total",
+        "description": "Number of rows inserted by queries in this database.",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_tup_inserted_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_tup_returned_total",
+        "description": "Number of rows returned by queries in this database.",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_tup_returned_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_tup_updated_total",
+        "description": "Number of rows updated by queries in this database.",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_tup_updated_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_xact_commit_total",
+        "description": "Number of transactions in this database that have been committed.",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_xact_commit_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_stat_database_xact_rollback_total",
+        "line_label": "%name% %db%-%endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_stat_database_xact_rollback_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "db",
+                "value": "*"
+              },
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "pg_up",
+        "description": "Whether the PostgreSQL server is up or not.",
+        "line_label": "%name% %endpoint%-%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "vector_pg_up",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
From Vector's
docs (https://vector.dev/docs/reference/configuration/sources/postgresql_metrics/#pg_stat_database_xact_rollback_total), here's the list of all metrics we receive from the Vector sink in a list:

- [ ] pg_stat_bgwriter_buffers_alloc_total
- [ ] pg_stat_bgwriter_buffers_backend_fsync_total
- [ ] pg_stat_bgwriter_buffers_backend_total
- [ ] pg_stat_bgwriter_buffers_checkpoint_total
- [ ] pg_stat_bgwriter_buffers_clean_total
- [ ] pg_stat_bgwriter_checkpoint_sync_time_seconds_total
- [ ] pg_stat_bgwriter_checkpoint_write_time_seconds_total
- [ ] pg_stat_bgwriter_checkpoints_req_total
- [ ] pg_stat_bgwriter_checkpoints_timed_total
- [ ] pg_stat_bgwriter_maxwritten_clean_total
- [ ] pg_stat_bgwriter_stats_reset
- [ ] pg_stat_database_blk_read_time_seconds_total
- [ ] pg_stat_database_blk_write_time_seconds_total
- [ ] pg_stat_database_blks_hit_total
- [ ] pg_stat_database_blks_read_total
- [ ] pg_stat_database_checksum_failures_total
- [ ] pg_stat_database_checksum_last_failure
- [ ] pg_stat_database_conflicts_confl_bufferpin_total
- [ ] pg_stat_database_conflicts_confl_deadlock_total
- [ ] pg_stat_database_conflicts_confl_lock_total
- [ ] pg_stat_database_conflicts_confl_snapshot_total
- [ ] pg_stat_database_conflicts_confl_tablespace_total
- [ ] pg_stat_database_conflicts_total
- [ ] pg_stat_database_datid
- [X] pg_stat_database_deadlocks_total
- [X] pg_stat_database_numbackends
- [ ] pg_stat_database_stats_reset
- [X] pg_stat_database_temp_bytes_total
- [X] pg_stat_database_temp_files_total
- [X] pg_stat_database_tup_deleted_total
- [X] pg_stat_database_tup_fetched_total
- [X] pg_stat_database_tup_inserted_total
- [X] pg_stat_database_tup_returned_total
- [X] pg_stat_database_tup_updated_total
- [X] pg_stat_database_xact_commit_total
- [X] pg_stat_database_xact_rollback_total
- [X] up

This patch adds a magic dashboard that includes the checked items in the list above, in alphabetical order as listed in Vector's documentation.

A live version of this dashboard can be found on https://staging.lol/integrations-team/sites/6384ced8d2a5e46933d2d234/metrics/64d4a720e076bd6227e3036d (albeit in a different order). Suggestions for changes are welcome.

Part of https://github.com/appsignal/appsignal-processor-rs/issues/1069.