### PR TITLE
Update Erlang IO graph value format

### DIFF
--- a/dashboards/erlang/main.json
+++ b/dashboards/erlang/main.json
@@ -11,7 +11,8 @@
         "display": "line",
         "title": "IO",
         "line_label": "%type% - %hostname%",
-        "format": "number",
+        "format": "size",
+        "format_input": "kilobyte",
         "draw_null_as_zero": true,
         "metrics": [
           {


### PR DESCRIPTION
As discussed on https://github.com/appsignal/public_config/pull/56#discussion_r1364995004, this graph uses the value as kilobyte, but currently shows it as a number without context what that number means.

Update the graph definition to show the value as a file size.

[skip review]