### PR TITLE
Add MongoDB + Vector dashboards

### DIFF
--- a/dashboards/mongodb_vector/README.md
+++ b/dashboards/mongodb_vector/README.md
@@ -1,0 +1,26 @@
+# MongoDB dashboard (using Vector)
+
+AppSignal tracks MongoDB metrics through its [Vector sink](https://docs.appsignal.com/vector.html).
+When enabled, it shows a subset of the [metrics listed in Vector's documentation](https://vector.dev/docs/reference/configuration/sources/mongodb_metrics/) in three different dashboards:
+
+- the **Status** dashboard, which shows more accessible metrics about the MongoDB instances:
+  - **Memory usage** (`memory`): The memory usage of the MongoDB instance, by the kind of memory usage.
+  - **Network usage** (`network_bytes_total`): The network usage of the MongoDB instance, incoming and outgoing.
+  - **Document operations** (`mongod_metrics_document_total`): The amount of document operations performed on the MongoDB instance, by document operation type.
+  - **Network connections** (`connections`): The amount of network connections open on the MongoDB instance, by their status.
+  - **Transactions** (`mongod_wiredtiger_transactions_total`): The amount of transactions performed on the MongoDB instance, by their status or outcome.
+  - **Open sessions** (`mongod_wiredtiger_session_open_sessions`): The amount of sessions opened on the MongoDB instance.
+- the **WiredTiger** dashboard, which shows metrics about MongoDB's internal WiredTiger engine:
+  - **Journal operations** count (`mongod_wiredtiger_log_operations_total`): the count of journal operations performed on the MongoDB instance, by type.
+  - **Journal operations** in bytes (`mongod_wiredtiger_log_bytes_total`): the amount of payload received and bytes written in the MongoDB instance's journal.
+  - **Cache size** (`mongod_wiredtiger_cache_bytes`): the amount of data stored in the MongoDB instance's cache, by the type or status of the cache node.
+  - **Block manager** (`mongod_wiredtiger_blockmanager_bytes_total`): the amount of bytes read and written by the MongoDB instance's block manager.
+  - **Concurrent transaction tickets** (`mongod_wiredtiger_concurrent_transactions_available_tickets`): the amount of available concurrent transaction tickets in the MongoDB instance, by type. If all concurrent transaction tickets are taken by transactions in progress, new transactions will be queued.
+  - **Open cursor** (`mongod_metrics_cursor_open`): the amount of cursors open on the MongoDB instance, by state.
+- the **Replication** dashboard, which shows metrics about the internal replication processes of the MongoDB cluster:
+  - **Network replication** (`mongod_metrics_repl_network_bytes_total`): the amount of bytes read and written as part of the MongoDB cluster replication process.
+  - **Replication buffer** (`mongod_metrics_repl_buffer_size_bytes`): the size in bytes of the buffered replication operations waiting to be transmitted to other members of the cluster.
+  - **Replication executor queue** (`mongod_metrics_repl_executor_queue`): the size in bytes of the replication operations received from other clusters waiting to be applied, by operation type.
+  - **Replication apply time** (`mongod_metrics_repl_apply_batches_seconds_total`): the amount of time, in seconds (rounded to the nearest second) spent applying replication operations.
+
+All metrics are shown per host, meaning there's a line (or more) in each graph for each of the MongoDB instances connected to Vector.

--- a/dashboards/mongodb_vector/main.json
+++ b/dashboards/mongodb_vector/main.json
@@ -1,0 +1,207 @@
+{
+  "metric_keys": [
+    "mongod_metrics_document_total"
+  ],
+  "dashboard": {
+    "title": "MongoDB/Status",
+    "description": "The general status of your MongoDB instances monitored with Vector",
+    "visuals": [
+      {
+        "title": "Memory usage",
+        "description": "resident, by host",
+        "line_label": "%host%",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "megabyte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "memory",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "resident"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Network usage",
+        "description": "in bytes, by host, incoming and outgoing",
+        "line_label": "%state% (%host%)",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "network_bytes_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "state",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Document operations",
+        "description": "count, per host and type",
+        "line_label": "%state% (%host%)",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_metrics_document_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "state",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Network connections",
+        "description": "count, by host and state",
+        "line_label": "%state% (%host%)",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "connections",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "state",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Transactions",
+        "description": "event count, by host and type",
+        "line_label": "%type% (%host%)",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_wiredtiger_transactions_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Open sessions",
+        "description": "count, per host",
+        "line_label": "%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_wiredtiger_session_open_sessions",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      }
+    ]
+  }
+}

--- a/dashboards/mongodb_vector/main.json
+++ b/dashboards/mongodb_vector/main.json
@@ -34,6 +34,10 @@
               {
                 "key": "type",
                 "value": "resident"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -68,6 +72,10 @@
               {
                 "key": "state",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -101,6 +109,10 @@
               {
                 "key": "state",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -134,6 +146,10 @@
               {
                 "key": "state",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -167,6 +183,10 @@
               {
                 "key": "type",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -196,6 +216,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }

--- a/dashboards/mongodb_vector/replication.json
+++ b/dashboards/mongodb_vector/replication.json
@@ -30,6 +30,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -60,6 +64,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -93,6 +101,10 @@
               {
                 "key": "type",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -122,6 +134,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }

--- a/dashboards/mongodb_vector/replication.json
+++ b/dashboards/mongodb_vector/replication.json
@@ -1,0 +1,133 @@
+{
+  "metric_keys": [
+    "mongod_metrics_repl_network_bytes_total"
+  ],
+  "dashboard": {
+    "title": "MongoDB/Replication",
+    "description": "Metrics from MongoDB's cluster replication engine internals",
+    "visuals": [
+      {
+        "title": "Network replication",
+        "description": "in bytes, per host",
+        "line_label": "%host%",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_metrics_repl_network_bytes_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Replication buffer",
+        "description": "in bytes, per host",
+        "line_label": "%host%",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_metrics_repl_buffer_size_bytes",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Replication executor queue",
+        "description": "operations count, per state and host",
+        "line_label": "%type% (%host%)",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_metrics_repl_executor_queue",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Replication batch apply time",
+        "description": "in seconds, per host",
+        "line_label": "%host%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_metrics_repl_apply_batches_seconds_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      }
+    ]
+  }
+}

--- a/dashboards/mongodb_vector/wiredtiger.json
+++ b/dashboards/mongodb_vector/wiredtiger.json
@@ -33,6 +33,10 @@
               {
                 "key": "type",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -67,6 +71,10 @@
               {
                 "key": "type",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -101,6 +109,10 @@
               {
                 "key": "type",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -135,6 +147,10 @@
               {
                 "key": "type",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -168,6 +184,10 @@
               {
                 "key": "type",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }
@@ -201,6 +221,10 @@
               {
                 "key": "state",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "mongodb"
               }
             ]
           }

--- a/dashboards/mongodb_vector/wiredtiger.json
+++ b/dashboards/mongodb_vector/wiredtiger.json
@@ -1,0 +1,212 @@
+{
+  "metric_keys": [
+    "mongod_wiredtiger_log_operations_total"
+  ],
+  "dashboard": {
+    "title": "MongoDB/WiredTiger",
+    "description": "Metrics from MongoDB's WiredTiger database engine internals",
+    "visuals": [
+      {
+        "title": "Journal operations",
+        "description": "count, by host and type",
+        "line_label": "%type% (%host%)",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_wiredtiger_log_operations_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Journal operations",
+        "description": "in bytes, payload received and bytes written, by host",
+        "line_label": "%type% (%host%)",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_wiredtiger_log_bytes_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Cache size",
+        "description": "in bytes, per host and type",
+        "line_label": "%type% (%host%)",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_wiredtiger_cache_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Block manager",
+        "description": "in bytes read and written, per host",
+        "line_label": "%type% (%host%)",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_wiredtiger_blockmanager_bytes_total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Concurrent transaction tickets",
+        "description": "available count, by host and type",
+        "line_label": "%type% (%host%)",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_wiredtiger_concurrent_transactions_available_tickets",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "type",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Open cursors",
+        "description": "count, by host and state",
+        "line_label": "%state% (%host%)",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "mongod_metrics_cursor_open",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "endpoint",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "state",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      }
+    ]
+  }
+}

--- a/dashboards/postgres/README.md
+++ b/dashboards/postgres/README.md
@@ -1,6 +1,6 @@
-# PostgresQL Dashboard
+# PostgreSQL Dashboard
 
-AppSignal tracks PostgresQL metrics through its [Vector sink](https://docs.appsignal.com/vector.html).
+AppSignal tracks PostgreSQL metrics through its [Vector sink](https://docs.appsignal.com/vector.html).
 When enabled, it shows a subset of the [metrics listed in Vector's documentation](https://vector.dev/docs/reference/configuration/sources/postgresql_metrics/):
 
 - pg_stat_database_deadlocks_total

--- a/dashboards/postgres/main.json
+++ b/dashboards/postgres/main.json
@@ -33,6 +33,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -66,6 +70,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -99,6 +107,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -132,6 +144,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -165,6 +181,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -198,6 +218,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -231,6 +255,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -264,6 +292,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -297,6 +329,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -330,6 +366,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }
@@ -363,6 +403,10 @@
               {
                 "key": "host",
                 "value": "*"
+              },
+              {
+                "key": "vector_namespace",
+                "value": "postgresql"
               }
             ]
           }


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-processor-rs/issues/1337.

The metrics contain the `"vector_namespace"` tags implemented in the [Vector namespace tag processor PR](https://github.com/appsignal/appsignal-processor-rs/pull/1348).

See https://github.com/appsignal/test-setups/pull/161 for a test setup that will send these metrics.