### PR TITLE
Add add Automated Dashboard for Kubernetes Node metrics

### DIFF
--- a/dashboards/kubernetes/README.md
+++ b/dashboards/kubernetes/README.md
@@ -1,0 +1,25 @@
+# Kubernetes automated dashboard
+
+There is currently one automated dashboard for AppSignal for Kubernetes:
+
+- [Nodes](#nodes)
+
+## Nodes
+
+The Nodes dashboard uses Kubernetes node metrics extracted from the `/api/v1/nodes/<NODE>/proxy/stats/summary` API endpoint via [AppSignal for Kubernetes](https://github.com/appsignal/appsignal-kubernetes).
+The following metrics are reported through this automated dashboard:
+
+- node_cpu_usage_nano_cores
+- node_memory_usage_bytes
+- node_memory_available_bytes
+- node_swap_available_bytes
+- node_swap_usage_bytes
+- node_fs_available_bytes
+- node_fs_used_bytes
+- node_network_rx_bytes
+- node_network_tx_bytes
+- node_fs_inodes
+- node_fs_inodes_free
+- node_fs_inodes_used
+- node_rlimit_maxpid
+- node_rlimit_curproc

--- a/dashboards/kubernetes/node.json
+++ b/dashboards/kubernetes/node.json
@@ -1,0 +1,300 @@
+{
+  "metric_keys": [
+    "node_cpu_usage_nano_cores"
+  ],
+  "dashboard": {
+    "title": "Kubernetes Nodes",
+    "description": "",
+    "visuals": [
+      {
+        "title": "Node CPU Usage",
+        "description": "node_cpu_usage_nano_cores",
+        "line_label": "%name% %node%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "node_cpu_usage_nano_cores",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Node Memory Usage",
+        "description": "node_memory_usage_bytes vs node_memory_available_bytes",
+        "line_label": "%name% %node%",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "node_memory_usage_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "node_memory_available_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Node Swap",
+        "description": "node_swap_usage_bytes vs. node_swap_available_bytes",
+        "line_label": "%name% %node%",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "node_swap_available_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "node_swap_usage_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Node File System Usage",
+        "description": "node_fs_used_bytes vs node_fs_available_bytes",
+        "line_label": "%name% %node%",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "node_fs_available_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "node_fs_used_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Node Network Traffic Received",
+        "description": "node_network_rx_bytes",
+        "line_label": "%name% %node%",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "node_network_rx_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Node Network Traffic Transmitted",
+        "description": "node_network_tx_bytes",
+        "line_label": "%name% %node%",
+        "display": "LINE",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "node_network_tx_bytes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Node Inodes Usage",
+        "description": "node_fs_inodes_free & node_fs_inodes_used vs node_fs_inodes",
+        "line_label": "%name% %node%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "node_fs_inodes",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "node_fs_inodes_free",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "node_fs_inodes_used",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "title": "Node Resource Limits",
+        "description": "node_rlimit_curproc vs node_rlimit_maxpid",
+        "line_label": "%name% %node%",
+        "display": "LINE",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "node_rlimit_maxpid",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "node_rlimit_curproc",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "node",
+                "value": "*"
+              }
+            ]
+          }
+        ],
+        "type": "timeseries"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
AppSignal for Kubernetes extracts node metrics for each node running in a Kubenetes cluster. This automated dashboard displays some of those metrics in an automated dashboard named "Kubernetes Nodes".