### PR TITLE
Add dashboard for Kubernetes pods

### DIFF
--- a/dashboards/kubernetes/README.md
+++ b/dashboards/kubernetes/README.md
@@ -3,6 +3,7 @@
 There is currently one automated dashboard for AppSignal for Kubernetes:
 
 - [Nodes](#nodes)
+- [Pods](#pods)
 
 ## Nodes
 
@@ -23,3 +24,14 @@ The following metrics are reported through this automated dashboard:
 - node_fs_inodes_used
 - node_rlimit_maxpid
 - node_rlimit_curproc
+
+## Pods
+
+The Nodes dashboard uses Kubernetes node metrics extracted from the `/api/v1/nodes/<NODE>/proxy/stats/summary` API endpoint via [AppSignal for Kubernetes](https://github.com/appsignal/appsignal-kubernetes).
+The following metrics are reported through this automated dashboard:
+
+- pod_cpu_usage_nano_cores
+- pod_cpu_usage_core_nano_seconds
+- pod_memory_working_set_bytes
+- pod_swap_available_bytes
+- pod_swap_usage_bytesc

--- a/dashboards/kubernetes/README.md
+++ b/dashboards/kubernetes/README.md
@@ -1,6 +1,6 @@
 # Kubernetes automated dashboard
 
-There is currently one automated dashboard for AppSignal for Kubernetes:
+The following automated dashboards exist for AppSignal for Kubernetes:
 
 - [Nodes](#nodes)
 - [Pods](#pods)

--- a/dashboards/kubernetes/pod.json
+++ b/dashboards/kubernetes/pod.json
@@ -1,0 +1,102 @@
+{
+  "metric_keys": [
+    "pod_cpu_usage_nano_cores"
+  ],
+  "dashboard": {
+    "title": "Kubernetes Pods",
+    "description": "",
+    "visuals": [
+      {
+	"title": "Pod CPU Usage",
+	"description": "pod_cpu_usage_nano_cores",
+	"line_label": "%name% %pod%",
+	"display": "LINE",
+	"format": "number",
+	"draw_null_as_zero": true,
+	"metrics": [
+	  {
+	    "name": "pod_cpu_usage_nano_cores",
+	    "fields": [
+	      {
+		"field": "GAUGE"
+	      }
+	    ],
+	    "tags": [
+	      {
+		"key": "pod",
+		"value": "*"
+	      }
+	    ]
+	  }
+	],
+	"type": "timeseries"
+      },
+      {
+	"title": "Pod Memory Usage",
+	"description": "pod_memory_usage_bytes vs pod_memory_available_bytes",
+	"line_label": "%name% %pod%",
+	"display": "LINE",
+	"format": "size",
+	"format_input": "byte",
+	"draw_null_as_zero": true,
+	"metrics": [
+	  {
+	    "name": "pod_memory_working_set_bytes",
+	    "fields": [
+	      {
+		"field": "GAUGE"
+	      }
+	    ],
+	    "tags": [
+	      {
+		"key": "pod",
+		"value": "*"
+	      }
+	    ]
+	  }
+	],
+	"type": "timeseries"
+      },
+      {
+	"title": "Pod Swap",
+	"description": "pod_swap_usage_bytes vs. pod_swap_available_bytes",
+	"line_label": "%name% %pod%",
+	"display": "LINE",
+	"format": "size",
+	"format_input": "byte",
+	"draw_null_as_zero": true,
+	"metrics": [
+	  {
+	    "name": "pod_swap_available_bytes",
+	    "fields": [
+	      {
+		"field": "GAUGE"
+	      }
+	    ],
+	    "tags": [
+	      {
+		"key": "pod",
+		"value": "*"
+	      }
+	    ]
+	  },
+	  {
+	    "name": "pod_swap_usage_bytes",
+	    "fields": [
+	      {
+		"field": "GAUGE"
+	      }
+	    ],
+	    "tags": [
+	      {
+		"key": "pod",
+		"value": "*"
+	      }
+	    ]
+	  }
+	],
+	"type": "timeseries"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Much like #64, but for pods. Part of https://github.com/appsignal/appsignal-kubernetes/pull/2.