### PR TITLE
Add Render automatic dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Automated Dashboards can be found in the `dashboards/` sub directory. Each direc
 - [Oban](/dashboards/oban/)
 - [Puma](/dashboards/puma/)
 - [PostgreSQL](/dashboards/postgresql/) (via Vector)
+- [Render](/dashboards/render/)
 - [Ruby VM](/dashboards/ruby_vm/)
 - [Sidekiq](/dashboards/sidekiq/)
 - [Karafka](/dashboards/karafka/)

--- a/dashboards/render/README.md
+++ b/dashboards/render/README.md
@@ -1,0 +1,51 @@
+# Render automated dashboards
+
+[Render](https://render.com/) is a cloud platform-as-a-service for running web services, background workers, persistent disks, Postgres databases and Key Value (Valkey/Redis) instances.
+
+These dashboards display data emitted by Render's [OpenTelemetry metrics stream](https://render.com/docs/metrics-streams), forwarded to AppSignal through the AppSignal collector. The collector's Render router converts CPU, memory, disk usage, disk I/O and network I/O metrics into host metrics; the remaining `render.*` metrics are exposed as custom metrics and power these dashboards.
+
+The following automated dashboards may appear:
+
+- [HTTP automated dashboard](#http-automated-dashboard)
+- [Postgres automated dashboard](#postgres-automated-dashboard)
+- [Key Value automated dashboard](#key-value-automated-dashboard)
+
+All three dashboards are currently marked Beta.
+
+## HTTP automated dashboard
+
+The "Render/HTTP" dashboard shows request volume and latency for Render web services. Render aggregates these metrics across all instances of a service, so each line corresponds to a host/status_code combination across the whole service rather than to a specific replica.
+
+The following graphs are displayed in this automated dashboard:
+
+- HTTP requests (broken down by status code and host)
+- HTTP latency (p50/p95/p99 broken down by host and status code)
+
+These graphs display values from the `render.service.http.requests.total` and `render.service.http.requests.latency` metrics.
+
+## Postgres automated dashboard
+
+The "Render/Postgres" dashboard shows information about Render Postgres instances.
+
+The following graphs are displayed in this automated dashboard:
+
+- Connections (active connections per database, compared against the connection limit)
+- Storage size (database size and indexes size per database)
+- Transaction volume
+- Sequential table scans (per database)
+- Transaction exhaustion (per database)
+- Slow locks
+- Slow lock wait time
+- Replication lag (per replica host)
+
+These graphs display values from the `render.postgres.*` metrics.
+
+## Key Value automated dashboard
+
+The "Render/Key Value" dashboard shows connection metrics for Render Key Value (Valkey/Redis) services. CPU, memory, disk and network usage for Key Value services are reported as host metrics and appear on the host metrics dashboard instead.
+
+The following graphs are displayed in this automated dashboard:
+
+- Connections (active connections compared against the connection limit)
+
+This graph displays values from the `render.keyvalue.connections` and `render.keyvalue.connection.limit` metrics.

--- a/dashboards/render/http.json
+++ b/dashboards/render/http.json
@@ -1,0 +1,87 @@
+{
+  "metric_keys": ["render.service.http.requests.total"],
+  "dashboard": {
+    "title": "Render/HTTP",
+    "description": "HTTP request volume and latency for Render web services",
+    "visuals": [
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "HTTP requests",
+        "description": "Number of HTTP requests received, broken down by host and status code.",
+        "line_label": "%status_code% %host% %service.name%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "render.service.http.requests.total",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "status_code",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "HTTP latency",
+        "description": "Response latency at the p50, p95 and p99 percentiles, broken down by host and status code.",
+        "line_label": "p%quantile% %status_code% %host% %service.name%",
+        "format": "duration",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "render.service.http.requests.latency",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "host",
+                "value": "*"
+              },
+              {
+                "key": "status_code",
+                "value": "*"
+              },
+              {
+                "key": "quantile",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/dashboards/render/key_value.json
+++ b/dashboards/render/key_value.json
@@ -1,0 +1,56 @@
+{
+  "metric_keys": ["render.keyvalue.connections"],
+  "dashboard": {
+    "title": "Render/Key Value",
+    "description": "Key Value (Valkey/Redis) metrics from Render's OpenTelemetry metrics stream",
+    "visuals": [
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Connections",
+        "description": "Number of active connections to the Key Value instance, alongside the instance's connection limit.",
+        "line_label": "%name% %service.name%",
+        "format": "number",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "render.keyvalue.connections",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "render.keyvalue.connection.limit",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/dashboards/render/postgres.json
+++ b/dashboards/render/postgres.json
@@ -1,0 +1,324 @@
+{
+  "metric_keys": ["render.postgres.connections"],
+  "dashboard": {
+    "title": "Render/Postgres",
+    "description": "PostgreSQL metrics from Render's OpenTelemetry metrics stream",
+    "visuals": [
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Connections",
+        "description": "Active connections to the Postgres instance, broken down by database, alongside the instance's connection limit.",
+        "line_label": "%database_name% %name% %service.name%",
+        "format": "number",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "render.postgres.connections",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "database_name",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "render.postgres.connection.limit",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Storage size",
+        "description": "On-disk size of each database (database.size) and combined size of all indexes within each database (indexes.size).",
+        "line_label": "%database_name% %name% %service.name%",
+        "format": "size",
+        "format_input": "byte",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "render.postgres.database.size",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "database_name",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "render.postgres.indexes.size",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "database_name",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Transaction volume",
+        "description": "Number of committed or rolled-back transactions on the Postgres instance.",
+        "line_label": "%service.name%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "render.postgres.transaction.volume",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Sequential table scans",
+        "description": "Number of sequential scans performed against tables in each database.",
+        "line_label": "%database_name% %service.name%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "render.postgres.table.scans",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "database_name",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Transaction exhaustion",
+        "description": "Percentage of available transactions used by each database. A persistently high value indicates pending wraparound risk and that VACUUM may need to be tuned.",
+        "line_label": "%database_name% %service.name%",
+        "format": "percent",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "render.postgres.transaction.exhaustion",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "database_name",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Slow locks",
+        "description": "Number of slow locks observed on the Postgres instance.",
+        "line_label": "%service.name%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "render.postgres.slow.lock.count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Slow lock wait time",
+        "description": "Cumulative wait time for slow locks on the Postgres instance, in seconds.",
+        "line_label": "%service.name%",
+        "format": "number",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "render.postgres.slow.lock.time",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Replication lag",
+        "description": "Delay between change on the primary and full replication (replication.lag) or transaction application (replication.apply.lag) on each read replica.",
+        "line_label": "%replication_host% %name% %service.name%",
+        "format": "duration",
+        "draw_null_as_zero": false,
+        "metrics": [
+          {
+            "name": "render.postgres.replication.lag",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "replication_host",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "render.postgres.replication.apply.lag",
+            "fields": [
+              {
+                "field": "GAUGE"
+              }
+            ],
+            "tags": [
+              {
+                "key": "service.instance.id",
+                "value": "*"
+              },
+              {
+                "key": "service.name",
+                "value": "*"
+              },
+              {
+                "key": "replication_host",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Part of https://github.com/appsignal/dev/issues/79. See also https://github.com/appsignal/appsignal-web/pull/448 for partial screenshots.

Add automatic dashboards for Render HTTP requests, Postgres and Redis.