### PR TITLE
Add Pgbus automated dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Automated Dashboards can be found in the `dashboards/` sub directory. Each direc
 - [NGINX](/dashboards/nginx/)
 - [Node.js](/dashboards/nodejs/)
 - [Oban](/dashboards/oban/)
+- [Pgbus](/dashboards/pgbus/) (via AppSignal for Ruby)
 - [PostgreSQL](/dashboards/postgres/) (via Vector)
 - [Process Memory](/dashboards/process_memory/)
 - [Puma](/dashboards/puma/)

--- a/dashboards/pgbus/README.md
+++ b/dashboards/pgbus/README.md
@@ -1,0 +1,104 @@
+# Pgbus automated dashboard
+
+[Pgbus](https://github.com/mhenrixon/pgbus) is a PostgreSQL-native job processing and event bus for Rails, built on [PGMQ](https://github.com/pgmq/pgmq).
+
+When using the AppSignal integration that ships with the pgbus gem (enabled automatically when the `appsignal` gem is loaded), the Pgbus automated dashboard will appear. Pgbus reports metrics through an `ActiveSupport::Notifications` subscriber and a minutely probe. See the [pgbus AppSignal integration](https://github.com/mhenrixon/pgbus/blob/main/lib/pgbus/integrations/appsignal.rb) for the full list of metrics.
+
+The following graphs are displayed in this automated dashboard:
+
+- [Job status per queue](#job-status-per-queue)
+- [Throughput per job class](#throughput-per-job-class)
+- [Duration per job class](#duration-per-job-class)
+- [Queue depth](#queue-depth)
+- [Queue latency](#queue-latency)
+- [Dead letter queue depth](#dead-letter-queue-depth)
+- [Worker / Process count](#worker--process-count)
+- [Messages sent / read](#messages-sent--read)
+- [Event handler status](#event-handler-status)
+- [Worker recycling](#worker-recycling)
+- [Database health](#database-health)
+- [Stream broadcasts](#stream-broadcasts)
+
+## Job status per queue
+
+The "Job status per queue" graph shows the number of jobs that were processed, failed, or dead-lettered, broken down per queue.
+
+This graph displays values from the `pgbus_queue_job_count` metric. This graph will show a line for each combination of values of the following metric tags:
+
+- The **queue** in which each job was enqueued.
+- The **status** of the job (`processed`, `failed`, or `dead_lettered`).
+
+## Throughput per job class
+
+The "Throughput per job class" graph shows the number of jobs executed per job class.
+
+This graph displays the `count` field of the `transaction_duration` metric, filtered to the `background` namespace, with a line per **action** (job class).
+
+## Duration per job class
+
+The "Duration per job class" graph shows the mean execution time per job class.
+
+This graph displays the `mean` field of the `transaction_duration` metric, filtered to the `background` namespace, with a line per **action** (job class).
+
+## Queue depth
+
+The "Queue depth" graph shows the total number of messages waiting in each queue.
+
+This graph displays values from the `pgbus_queue_depth` metric. This graph will show a line for each combination of values of the following metric tags:
+
+- The **queue** being measured.
+- The **hostname** of the process that reported the metric.
+
+## Queue latency
+
+The "Queue latency" graph shows the age of the oldest message in each queue, in milliseconds. High latency means consumers can't keep up with the rate of incoming messages.
+
+This graph displays values from the `pgbus_queue_latency` metric. This graph will show a line for each combination of values of the following metric tags:
+
+- The **queue** being measured.
+- The **hostname** of the process that reported the metric.
+
+## Dead letter queue depth
+
+The "Dead letter queue depth" graph shows the number of messages that exceeded their max retries and were routed to a dead letter queue.
+
+This graph displays values from the `pgbus_dlq_depth` metric, with a line per **hostname**.
+
+## Worker / Process count
+
+The "Worker / Process count" graph shows the number of active pgbus supervisor processes.
+
+This graph displays values from the `pgbus_active_processes` metric, with a line per **hostname**.
+
+## Messages sent / read
+
+The "Messages sent / read" graph shows PGMQ message throughput: how many messages were enqueued (`pgbus_messages_sent`) and dequeued (`pgbus_messages_read`).
+
+Both metrics show a line per **queue**.
+
+## Event handler status
+
+The "Event handler status" graph shows the number of processed and failed event-bus handler invocations.
+
+This graph displays values from the `pgbus_event_count` metric. This graph will show a line for each combination of values of the following metric tags:
+
+- The **handler** class that processed each event.
+- The **status** of the invocation (`processed` or `failed`).
+
+## Worker recycling
+
+The "Worker recycling" graph shows the number of worker recycle events, broken down by reason.
+
+This graph displays values from the `pgbus_worker_recycled` metric, with a line per **reason** (`max_jobs`, `max_memory`, or `max_lifetime`). Pgbus recycles workers on these thresholds to prevent unbounded memory growth.
+
+## Database health
+
+The "Database health" graph shows the number of dead tuples in queue/archive tables (`pgbus_total_dead_tuples`) and how many tables currently need a vacuum (`pgbus_tables_needing_vacuum`).
+
+Both metrics show a line per **hostname**. These are indicators of MVCC pressure on the PGMQ queue tables.
+
+## Stream broadcasts
+
+The "Stream broadcasts" graph shows the number of Turbo Stream broadcasts over the last 60 minutes (`pgbus_stream_broadcasts_60m`) and the number of active SSE connections (`pgbus_stream_active_connections`).
+
+Both metrics show a line per **hostname**.

--- a/dashboards/pgbus/main.json
+++ b/dashboards/pgbus/main.json
@@ -1,0 +1,377 @@
+{
+  "metric_keys": [
+    "pgbus_queue_job_count"
+  ],
+  "dashboard": {
+    "title": "Pgbus",
+    "description": "PostgreSQL-native job processing and event bus built on PGMQ.\nMonitor job throughput, queue depth, latency, dead letter queues,\nworker processes, event handlers, and stream broadcasts.\n",
+    "visuals": [
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Job status per queue",
+        "description": "Processed, failed, and dead-lettered jobs per queue.",
+        "line_label": "%queue% - %status%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_job_count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "status",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Throughput per job class",
+        "description": "Number of jobs executed per job class.",
+        "line_label": "%namespace% - %action%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "transaction_duration",
+            "fields": [
+              {
+                "field": "count"
+              }
+            ],
+            "tags": [
+              {
+                "key": "namespace",
+                "value": "background"
+              },
+              {
+                "key": "action",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Duration per job class",
+        "description": "Mean execution time per job class.",
+        "line_label": "%namespace% - %action%",
+        "format": "duration",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "transaction_duration",
+            "fields": [
+              {
+                "field": "mean"
+              }
+            ],
+            "tags": [
+              {
+                "key": "namespace",
+                "value": "background"
+              },
+              {
+                "key": "action",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Queue depth",
+        "description": "Total messages waiting in each queue.",
+        "line_label": "%hostname% - %queue%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_depth",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Queue latency",
+        "description": "Age of the oldest message in each queue (milliseconds). High latency means consumers can't keep up.",
+        "line_label": "%hostname% - %queue%",
+        "format": "duration",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_queue_latency",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              },
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Dead letter queue depth",
+        "description": "Messages that exceeded max retries and were routed to the DLQ.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_dlq_depth",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Worker / Process count",
+        "description": "Active pgbus supervisor processes.",
+        "line_label": "%hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_active_processes",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Messages sent / read",
+        "description": "PGMQ message throughput: enqueue and dequeue rates.",
+        "line_label": "%name% - %queue%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_messages_sent",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "pgbus_messages_read",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "queue",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Event handler status",
+        "description": "Processed and failed event handler invocations.",
+        "line_label": "%handler% - %status%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_event_count",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "handler",
+                "value": "*"
+              },
+              {
+                "key": "status",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Worker recycling",
+        "description": "Worker recycle events by reason (max_jobs, max_memory, max_lifetime).",
+        "line_label": "%reason%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_worker_recycled",
+            "fields": [
+              {
+                "field": "COUNTER"
+              }
+            ],
+            "tags": [
+              {
+                "key": "reason",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Database health",
+        "description": "Dead tuples and oldest transaction age — indicators of MVCC pressure on queue tables.",
+        "line_label": "%name% - %hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_total_dead_tuples",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "pgbus_tables_needing_vacuum",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "timeseries",
+        "display": "LINE",
+        "title": "Stream broadcasts",
+        "description": "Turbo Stream broadcast count and active SSE connections.",
+        "line_label": "%name% - %hostname%",
+        "format": "number",
+        "draw_null_as_zero": true,
+        "metrics": [
+          {
+            "name": "pgbus_stream_broadcasts_60m",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "name": "pgbus_stream_active_connections",
+            "fields": [
+              {
+                "field": "gauge"
+              }
+            ],
+            "tags": [
+              {
+                "key": "hostname",
+                "value": "*"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/dashboards/pgbus/main.json
+++ b/dashboards/pgbus/main.json
@@ -98,7 +98,7 @@
         "display": "LINE",
         "title": "Queue depth",
         "description": "Total messages waiting in each queue.",
-        "line_label": "%hostname% - %queue%",
+        "line_label": "%queue%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -113,10 +113,6 @@
               {
                 "key": "queue",
                 "value": "*"
-              },
-              {
-                "key": "hostname",
-                "value": "*"
               }
             ]
           }
@@ -127,7 +123,7 @@
         "display": "LINE",
         "title": "Queue latency",
         "description": "Age of the oldest message in each queue (milliseconds). High latency means consumers can't keep up.",
-        "line_label": "%hostname% - %queue%",
+        "line_label": "%queue%",
         "format": "duration",
         "draw_null_as_zero": true,
         "metrics": [
@@ -142,10 +138,6 @@
               {
                 "key": "queue",
                 "value": "*"
-              },
-              {
-                "key": "hostname",
-                "value": "*"
               }
             ]
           }
@@ -156,7 +148,7 @@
         "display": "LINE",
         "title": "Dead letter queue depth",
         "description": "Messages that exceeded max retries and were routed to the DLQ.",
-        "line_label": "%hostname%",
+        "line_label": "DLQ depth",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -167,12 +159,7 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       },
@@ -180,7 +167,7 @@
         "type": "timeseries",
         "display": "LINE",
         "title": "Worker / Process count",
-        "description": "Active pgbus supervisor processes.",
+        "description": "Active pgbus supervisor processes per host.",
         "line_label": "%hostname%",
         "format": "number",
         "draw_null_as_zero": true,
@@ -298,8 +285,8 @@
         "type": "timeseries",
         "display": "LINE",
         "title": "Database health",
-        "description": "Dead tuples and oldest transaction age — indicators of MVCC pressure on queue tables.",
-        "line_label": "%name% - %hostname%",
+        "description": "Dead tuples, tables needing vacuum, and oldest transaction age — indicators of MVCC pressure on queue tables.",
+        "line_label": "%name%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -310,12 +297,7 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           },
           {
             "name": "pgbus_tables_needing_vacuum",
@@ -324,12 +306,16 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
+            "tags": []
+          },
+          {
+            "name": "pgbus_oldest_transaction_age_seconds",
+            "fields": [
               {
-                "key": "hostname",
-                "value": "*"
+                "field": "gauge"
               }
-            ]
+            ],
+            "tags": []
           }
         ]
       },
@@ -338,7 +324,7 @@
         "display": "LINE",
         "title": "Stream broadcasts",
         "description": "Turbo Stream broadcast count and active SSE connections.",
-        "line_label": "%name% - %hostname%",
+        "line_label": "%name%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [
@@ -349,12 +335,7 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           },
           {
             "name": "pgbus_stream_active_connections",
@@ -363,12 +344,7 @@
                 "field": "gauge"
               }
             ],
-            "tags": [
-              {
-                "key": "hostname",
-                "value": "*"
-              }
-            ]
+            "tags": []
           }
         ]
       }

--- a/dashboards/pgbus/main.json
+++ b/dashboards/pgbus/main.json
@@ -255,6 +255,10 @@
               {
                 "key": "status",
                 "value": "*"
+              },
+              {
+                "key": "routing_key",
+                "value": "*"
               }
             ]
           }

--- a/dashboards/pgbus/main.json
+++ b/dashboards/pgbus/main.json
@@ -236,7 +236,7 @@
         "display": "LINE",
         "title": "Event handler status",
         "description": "Processed and failed event handler invocations.",
-        "line_label": "%handler% - %status%",
+        "line_label": "%handler% - %status% - %routing_key%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [

--- a/dashboards/pgbus/main.json
+++ b/dashboards/pgbus/main.json
@@ -24,6 +24,10 @@
             ],
             "tags": [
               {
+                "key": "job_class",
+                "value": "*"
+              },
+              {
                 "key": "queue",
                 "value": "*"
               },

--- a/dashboards/pgbus/main.json
+++ b/dashboards/pgbus/main.json
@@ -11,7 +11,7 @@
         "display": "LINE",
         "title": "Job status per queue",
         "description": "Processed, failed, and dead-lettered jobs per queue.",
-        "line_label": "%queue% - %status%",
+        "line_label": "%job_class% - %queue% - %status%",
         "format": "number",
         "draw_null_as_zero": true,
         "metrics": [


### PR DESCRIPTION
## Add Pgbus automated dashboard

[Pgbus](https://github.com/mhenrixon/pgbus) is a PostgreSQL-native job processing and event bus for Rails, built on [PGMQ](https://github.com/pgmq/pgmq). It's an alternative to Sidekiq/SolidQueue that runs entirely on PostgreSQL.

The pgbus gem ships an AppSignal integration that's enabled automatically when the `appsignal` gem is present. It reports metrics through an `ActiveSupport::Notifications` subscriber (counters and distributions per job/event/message) and a minutely probe (queue depth, latency, DLQ, process counts, database health, stream stats). All metric names are prefixed `pgbus_` and gauges carry a `hostname` tag, matching the Sidekiq/Puma probe convention.

This PR adds the automated dashboard so it appears for pgbus users without manual setup.

### Trigger metric

`pgbus_queue_job_count` — emitted whenever a job is processed, fails, or is dead-lettered.

### Graphs

- Job status per queue (`pgbus_queue_job_count`)
- Throughput / Duration per job class (`transaction_duration`, `background` namespace)
- Queue depth (`pgbus_queue_depth`)
- Queue latency (`pgbus_queue_latency`)
- Dead letter queue depth (`pgbus_dlq_depth`)
- Worker / Process count (`pgbus_active_processes`)
- Messages sent / read (`pgbus_messages_sent`, `pgbus_messages_read`)
- Event handler status (`pgbus_event_count`)
- Worker recycling (`pgbus_worker_recycled`)
- Database health (`pgbus_total_dead_tuples`, `pgbus_tables_needing_vacuum`)
- Stream broadcasts (`pgbus_stream_broadcasts_60m`, `pgbus_stream_active_connections`)

### Validation

`rake validate` passes with no issues.

The integration source lives in [`lib/pgbus/integrations/appsignal.rb`](https://github.com/mhenrixon/pgbus/blob/main/lib/pgbus/integrations/appsignal.rb) and its probe/subscriber in the same directory. Happy to adjust naming, graph selection, or descriptions to match your conventions.
