### PR TITLE
Fix stale docs.appsignal.com links in dashboard READMEs

### DIFF
--- a/dashboards/heroku/README.md
+++ b/dashboards/heroku/README.md
@@ -4,7 +4,7 @@
 
 This README uses the existing [Heroku dashboards documentation](https://docs.appsignal.com/heroku/dashboards.html) as reference.
 
-When using [the AppSignal Heroku log drain](https://docs.appsignal.com/heroku/setup-logdrain.html) to send data about your Heroku application to AppSignal, the following automated dashboards may appear:
+When using [the AppSignal Heroku log drain](https://docs.appsignal.com/heroku/setup.html) to send data about your Heroku application to AppSignal, the following automated dashboards may appear:
 
 - [Status automated dashboard](#status-automated-dashboard)
 - [Redis automated dashboard](#redis-automated-dashboard)

--- a/dashboards/heroku/README.md
+++ b/dashboards/heroku/README.md
@@ -4,7 +4,7 @@
 
 This README uses the existing [Heroku dashboards documentation](https://docs.appsignal.com/heroku/dashboards.html) as reference.
 
-When using [the AppSignal Heroku log drain](https://docs.appsignal.com/heroku/setup.html) to send data about your Heroku application to AppSignal, the following automated dashboards may appear:
+When using [the AppSignal Heroku log drain](https://docs.appsignal.com/heroku/setup) to send data about your Heroku application to AppSignal, the following automated dashboards may appear:
 
 - [Status automated dashboard](#status-automated-dashboard)
 - [Redis automated dashboard](#redis-automated-dashboard)

--- a/dashboards/nginx/README.md
+++ b/dashboards/nginx/README.md
@@ -2,6 +2,6 @@
 
 [NGINX](https://nginx.org/) is a performant HTTP server and reverse proxy, commonly used as a first layer when handling traffic for web applications.
 
-When using [the NGINX metrics integration](https://docs.appsignal.com/metrics/nginx.html#magic-dashboard), the NGINX automated dashboard will appear.
+When using [the NGINX metrics integration](https://docs.appsignal.com/metrics/nginx.html#intelligence-dashboard), the NGINX automated dashboard will appear.
 
-See the [NGINX automated dashboard documentation](https://docs.appsignal.com/metrics/nginx.html#magic-dashboard) and [metrics documentation](https://docs.appsignal.com/metrics/nginx.html#metrics) for details on the graphs displayed by this dashboard.
+See the [NGINX automated dashboard documentation](https://docs.appsignal.com/metrics/nginx.html#intelligence-dashboard) and [metrics documentation](https://docs.appsignal.com/metrics/nginx.html#metrics) for details on the graphs displayed by this dashboard.

--- a/dashboards/nginx/README.md
+++ b/dashboards/nginx/README.md
@@ -2,6 +2,6 @@
 
 [NGINX](https://nginx.org/) is a performant HTTP server and reverse proxy, commonly used as a first layer when handling traffic for web applications.
 
-When using [the NGINX metrics integration](https://docs.appsignal.com/metrics/nginx.html#intelligence-dashboard), the NGINX automated dashboard will appear.
+When using [the NGINX metrics integration](https://docs.appsignal.com/metrics/nginx#intelligence-dashboard), the NGINX automated dashboard will appear.
 
-See the [NGINX automated dashboard documentation](https://docs.appsignal.com/metrics/nginx.html#intelligence-dashboard) and [metrics documentation](https://docs.appsignal.com/metrics/nginx.html#metrics) for details on the graphs displayed by this dashboard.
+See the [NGINX automated dashboard documentation](https://docs.appsignal.com/metrics/nginx#intelligence-dashboard) and [metrics documentation](https://docs.appsignal.com/metrics/nginx.html#metrics) for details on the graphs displayed by this dashboard.

--- a/dashboards/nginx/main.json
+++ b/dashboards/nginx/main.json
@@ -4,7 +4,7 @@
   ],
   "dashboard": {
     "title": "NGINX",
-    "description": "NGINX server metrics: https://docs.appsignal.com/metrics/nginx.html#intelligence-dashboard",
+    "description": "NGINX server metrics: https://docs.appsignal.com/metrics/nginx#intelligence-dashboard",
     "visuals": [
       {
         "title": "Request time",

--- a/dashboards/nginx/main.json
+++ b/dashboards/nginx/main.json
@@ -4,7 +4,7 @@
   ],
   "dashboard": {
     "title": "NGINX",
-    "description": "NGINX server metrics: https://docs.appsignal.com/metrics/nginx.html#magic-dashboard",
+    "description": "NGINX server metrics: https://docs.appsignal.com/metrics/nginx.html#intelligence-dashboard",
     "visuals": [
       {
         "title": "Request time",

--- a/dashboards/sidekiq/README.md
+++ b/dashboards/sidekiq/README.md
@@ -1,3 +1,3 @@
 # Sidekiq automated dashboard
 
-See our [Sidekiq documentation](https://docs.appsignal.com/ruby/integrations/sidekiq.html#minutely-probe) for more information about which metrics are reported by our Sidekiq instrumentation.
+See our [Sidekiq documentation](https://docs.appsignal.com/ruby/integrations/sidekiq.html#intelligence-dashboard) for more information about which metrics are reported by our Sidekiq instrumentation.

--- a/dashboards/sidekiq/README.md
+++ b/dashboards/sidekiq/README.md
@@ -1,3 +1,3 @@
 # Sidekiq automated dashboard
 
-See our [Sidekiq documentation](https://docs.appsignal.com/ruby/integrations/sidekiq.html#intelligence-dashboard) for more information about which metrics are reported by our Sidekiq instrumentation.
+See our [Sidekiq documentation](https://docs.appsignal.com/ruby/integrations/sidekiq#intelligence-dashboard) for more information about which metrics are reported by our Sidekiq instrumentation.


### PR DESCRIPTION
Fixes the `public_config` half of appsignal/appsignal-server#16838 (bullet 2), plus one extra broken link found while sweeping the repo.

## Changes

| File | Was | Now |
| --- | --- | --- |
| `dashboards/nginx/README.md` (x2) | `metrics/nginx.html#magic-dashboard` | `metrics/nginx.html#intelligence-dashboard` |
| `dashboards/nginx/main.json` | `metrics/nginx.html#magic-dashboard` | `metrics/nginx.html#intelligence-dashboard` |
| `dashboards/heroku/README.md` | `heroku/setup-logdrain.html` (404) | `heroku/setup.html` |
| `dashboards/sidekiq/README.md` | `ruby/integrations/sidekiq.html#minutely-probe` | `ruby/integrations/sidekiq.html#intelligence-dashboard` |

The Sidekiq one wasn't in the issue. The page itself resolves, but the `#minutely-probe` anchor no longer exists, so the link landed at the top of the page. The section documenting which metrics are reported is now "Intelligence dashboard".

For Heroku I used `heroku/setup.html` rather than the bare `heroku/setup` suggested in the issue, to match the `.html` suffix used by every other link in this repo. Both resolve.

