### PR TITLE
Apply must and minor fixes to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ The `public_config` repository is a place for AppSignal's public configuration. 
 
 ## Automated Dashboards
 
-Automated Dashboards can be found in the `dashboards/` sub directory. Each directory is a different integration, like a language or package. Each dashboard is its own file in these sub-directories in the JSON format:
+Automated Dashboards can be found in the `dashboards/` sub directory. Each directory is a different integration, like a language or package. Each dashboard is its own file in these sub-directories in the JSON format.
+
+Some integrations ship more than one dashboard, so there are more dashboards than directories.
 
 - [Action Mailer](/dashboards/action_mailer/)
 - [Active Job](/dashboards/active_job/)
-- [AWS](/dashboards/aws/) (via AWS CloudWatch)
+- [AWS](/dashboards/aws/) (via AWS CloudWatch) — [generated, do not edit here](#generated-dashboards)
 - [AWS CloudWatch Metric Streams](/dashboards/cloudwatch/)
 - [Ecto](/dashboards/ecto/)
 - [Erlang](/dashboards/erlang/)
@@ -19,7 +21,7 @@ Automated Dashboards can be found in the `dashboards/` sub directory. Each direc
 - [MongoDB](/dashboards/mongodb_vector/) (via Vector)
 - [Next.js](/dashboards/nextjs/) (deprecated)
 - [NGINX](/dashboards/nginx/)
-- [Node.js](/dashboards/nodejs/)
+- [Node.js](/dashboards/nodejs/) (the Postgres dashboard is deprecated)
 - [Oban](/dashboards/oban/)
 - [PostgreSQL](/dashboards/postgres/) (via Vector)
 - [Process Memory](/dashboards/process_memory/)
@@ -29,10 +31,16 @@ Automated Dashboards can be found in the `dashboards/` sub directory. Each direc
 - [Sidekiq](/dashboards/sidekiq/)
 - [Web Vitals](/dashboards/web-vitals/)
 
+### Generated dashboards
+
+The dashboards in [`dashboards/aws/`](/dashboards/aws/) are not maintained in this repository. They are generated and published here by AppSignal's internal `cloudwatch-dashboards` repository, and any edit made to them here will be overwritten on the next publish.
+
+Every other directory listed above is maintained in this repository and can be edited directly.
+
 ### Validation
 
 To validate all dashboards in this repository, run the following command. To pass the validation, fix any issues that are printed.
 
-```
+```sh
 rake validate
 ```

--- a/dashboards/action_mailer/README.md
+++ b/dashboards/action_mailer/README.md
@@ -2,11 +2,12 @@
 
 [ActionMailer](https://guides.rubyonrails.org/action_mailer_basics.html) is the e-mail delivery system built for Ruby on Rails.
 
-When using [the AppSignal for Ruby gem](https://docs.appsignal.com/ruby/integrations/mongodb.html) in an application that uses ActionMailer, the ActionMailer automated dashboard will appear.
+When using [the AppSignal for Ruby gem](https://docs.appsignal.com/ruby/integrations/rails) in an application that uses ActionMailer, the ActionMailer automated dashboard will appear.
 
 The following graphs are displayed in this automated dashboard:
 
-- [Deliveries](#deliveries)
+- [ActionMailer automated dashboard](#actionmailer-automated-dashboard)
+  - [Deliveries](#deliveries)
 
 ## Deliveries
 

--- a/dashboards/active_job/README.md
+++ b/dashboards/active_job/README.md
@@ -2,14 +2,16 @@
 
 [ActiveJob](https://guides.rubyonrails.org/active_job_basics.html) is the background job system built for Ruby on Rails.
 
-When using [the AppSignal for Ruby gem](https://docs.appsignal.com/ruby/integrations/mongodb.html) in an application that uses ActiveJob, the ActiveJob automated dashboard will appear.
+When using [the AppSignal for Ruby gem](https://docs.appsignal.com/ruby/integrations/active-job) in an application that uses ActiveJob, the ActiveJob automated dashboard will appear.
 
 The following graphs are displayed in this automated dashboard:
 
-- [Job status per queue](#job-status-per-queue)
-- [Job status per queue with priority](#job-status-per-queue-with-priority)
-- [Throughput per job class](#throughput-per-job-class)
-- [Duration per job class](#duration-per-job-class)
+- [ActiveJob automated dashboard](#activejob-automated-dashboard)
+  - [Job status per queue](#job-status-per-queue)
+  - [Job status per queue with priority](#job-status-per-queue-with-priority)
+  - [Throughput per job class](#throughput-per-job-class)
+  - [Duration per job class](#duration-per-job-class)
+  - [Queue time per queue](#queue-time-per-queue)
 
 ## Job status per queue
 

--- a/dashboards/aws/README.md
+++ b/dashboards/aws/README.md
@@ -1,3 +1,3 @@
 # AWS CloudWatch dashboards
 
-These dashboard files are managed by the [cloudwatch-dashboards](https://github.com/appsignal/cloudwatch-dashboards) repository. Do not edit them directly — changes will be overwritten on the next publish.
+These dashboard files are managed by AppSignal's internal `cloudwatch-dashboards` repository. Do not edit them directly — changes will be overwritten on the next publish.

--- a/dashboards/karafka/README.md
+++ b/dashboards/karafka/README.md
@@ -1,3 +1,3 @@
 # Karafka automated dashboard
 
-See the [Karafka documentation](https://karafka.io/docs/Monitoring-and-logging/#appsignal-metrics-and-error-tracking) for more information about which metrics are reported by the Karafka instrumentation.
+See the [Karafka documentation](https://karafka.io/docs/Monitoring-and-Logging/#appsignal-metrics-and-error-tracking) for more information about which metrics are reported by the Karafka instrumentation.


### PR DESCRIPTION
Clarify in the root `README.md` that some integrations ship more than one dashboard, document that the `dashboards/aws/` files are generated and should not be edited here, and flag the deprecated Node.js Postgres dashboard.

Fix three stale documentation links. The Action Mailer and Active Job READMEs pointed at MongoDB documentation, and the Karafka README returned a 404.

Replace the private `cloudwatch-dashboards` repository links with plain text, because they returned a 404 for readers outside AppSignal.
